### PR TITLE
feat: add support for parsing Firestore database references from string

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,9 @@ dependencies = [
  "futures",
  "googleapis",
  "itertools 0.12.1",
+ "rstest",
  "string_cache",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tonic 0.11.0",
@@ -566,6 +568,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,11 +609,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "googleapis"
 version = "0.0.0"
 dependencies = [
  "itertools 0.12.1",
  "prost",
+ "rstest",
  "thiserror",
  "time",
  "tonic 0.11.0",
@@ -1261,10 +1276,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "relative-path"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
+
+[[package]]
+name = "rstest"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustix"
@@ -1296,6 +1355,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"

--- a/crates/firestore-database/Cargo.toml
+++ b/crates/firestore-database/Cargo.toml
@@ -7,7 +7,11 @@ futures = { workspace = true }
 googleapis = { workspace = true }
 itertools = { workspace = true }
 string_cache = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tonic = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+rstest = "0.18.2"

--- a/crates/firestore-database/src/database/collection.rs
+++ b/crates/firestore-database/src/database/collection.rs
@@ -5,28 +5,32 @@ use tokio::sync::RwLock;
 use tonic::Result;
 use tracing::instrument;
 
-use super::document::DocumentMeta;
+use super::{
+    document::DocumentMeta,
+    reference::{CollectionRef, DocumentRef},
+};
 use crate::utils::RwLockHashMapExt;
 
 pub struct Collection {
-    pub name:  DefaultAtom,
+    pub name:  CollectionRef,
     documents: RwLock<HashMap<DefaultAtom, Arc<DocumentMeta>>>,
 }
 
 impl Collection {
     #[instrument(skip_all)]
-    pub fn new(name: DefaultAtom) -> Self {
+    pub fn new(name: CollectionRef) -> Self {
         Self {
             name,
             documents: Default::default(),
         }
     }
 
-    pub async fn get_doc(self: &Arc<Self>, name: &DefaultAtom) -> Arc<DocumentMeta> {
+    pub async fn get_doc(self: &Arc<Self>, name: &DocumentRef) -> Arc<DocumentMeta> {
+        debug_assert_eq!(self.name, name.collection_ref);
         Arc::clone(
             self.documents
-                .get_or_insert(name, || {
-                    Arc::new(DocumentMeta::new(name.clone(), self.name.clone()))
+                .get_or_insert(&name.document_id, || {
+                    Arc::new(DocumentMeta::new(name.clone()))
                 })
                 .await
                 .deref(),

--- a/crates/firestore-database/src/database/document.rs
+++ b/crates/firestore-database/src/database/document.rs
@@ -11,7 +11,6 @@ use googleapis::google::{
     firestore::v1::{precondition, Document, Value},
     protobuf::Timestamp,
 };
-use string_cache::DefaultAtom;
 use tokio::{
     sync::{
         oneshot, OwnedRwLockReadGuard, OwnedRwLockWriteGuard, OwnedSemaphorePermit, RwLock,
@@ -22,17 +21,14 @@ use tokio::{
 use tonic::{Code, Result, Status};
 use tracing::{instrument, trace, Level};
 
-use super::ReadConsistency;
+use super::{reference::DocumentRef, ReadConsistency};
 
 const WAIT_LOCK_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub struct DocumentMeta {
     /// The resource name of the document, for example
     /// `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
-    pub name: DefaultAtom,
-    /// The collection name of the document, i.e. the full name of the document minus the last
-    /// component.
-    pub collection_name: DefaultAtom,
+    pub name: DocumentRef,
     contents: Arc<RwLock<DocumentContents>>,
     write_permit_shop: Arc<Semaphore>,
 }
@@ -46,14 +42,10 @@ impl Debug for DocumentMeta {
 }
 
 impl DocumentMeta {
-    pub fn new(name: DefaultAtom, collection_name: DefaultAtom) -> Self {
+    pub fn new(name: DocumentRef) -> Self {
         Self {
-            contents: Arc::new(RwLock::new(DocumentContents::new(
-                name.clone(),
-                collection_name.clone(),
-            ))),
+            contents: Arc::new(RwLock::new(DocumentContents::new(name.clone()))),
             name,
-            collection_name,
             write_permit_shop: Arc::new(Semaphore::new(1)),
         }
     }
@@ -91,18 +83,14 @@ impl DocumentMeta {
 pub struct DocumentContents {
     /// The resource name of the document, for example
     /// `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
-    pub name: DefaultAtom,
-    /// The collection name of the document, i.e. the full name of the document minus the last
-    /// component.
-    pub collection_name: DefaultAtom,
+    pub name: DocumentRef,
     versions: Vec<DocumentVersion>,
 }
 
 impl DocumentContents {
-    pub fn new(name: DefaultAtom, collection_name: DefaultAtom) -> Self {
+    pub fn new(name: DocumentRef) -> Self {
         Self {
             name,
-            collection_name,
             versions: Default::default(),
         }
     }
@@ -172,7 +160,7 @@ impl DocumentContents {
     }
 
     #[instrument(skip_all, fields(
-        doc_name = self.name.deref(),
+        doc_name = %self.name,
         time = display(&update_time),
     ), level = Level::DEBUG)]
     pub async fn add_version(
@@ -184,7 +172,6 @@ impl DocumentContents {
         let create_time = self.create_time().unwrap_or_else(|| update_time.clone());
         let version = DocumentVersion::Stored(Arc::new(StoredDocumentVersion {
             name: self.name.clone(),
-            collection_name: self.collection_name.clone(),
             create_time,
             update_time,
             fields,
@@ -196,7 +183,6 @@ impl DocumentContents {
     pub async fn delete(&mut self, delete_time: Timestamp) -> DocumentVersion {
         let version = DocumentVersion::Deleted(Arc::new(DeletedDocumentVersion {
             name: self.name.clone(),
-            collection_name: self.collection_name.clone(),
             delete_time,
         }));
         self.versions.push(version.clone());
@@ -250,7 +236,7 @@ pub enum DocumentVersion {
 }
 
 impl DocumentVersion {
-    pub fn name(&self) -> &DefaultAtom {
+    pub fn name(&self) -> &DocumentRef {
         match self {
             DocumentVersion::Deleted(ver) => &ver.name,
             DocumentVersion::Stored(ver) => &ver.name,
@@ -287,10 +273,7 @@ impl DocumentVersion {
 pub struct StoredDocumentVersion {
     /// The resource name of the document, for example
     /// `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
-    pub name: DefaultAtom,
-    /// The collection name of the document, i.e. the full name of the document minus the last
-    /// component.
-    pub collection_name: DefaultAtom,
+    pub name: DocumentRef,
     /// The time at which the document was created.
     ///
     /// This value increases monotonically when a document is deleted then
@@ -345,10 +328,7 @@ impl StoredDocumentVersion {
 pub struct DeletedDocumentVersion {
     /// The resource name of the document, for example
     /// `projects/{project_id}/databases/{database_id}/documents/{document_path}`.
-    pub name: DefaultAtom,
-    /// The collection name of the document, i.e. the full name of the document minus the last
-    /// component.
-    pub collection_name: DefaultAtom,
+    pub name: DocumentRef,
     /// The time at which the document was deleted.
     pub delete_time: Timestamp,
 }

--- a/crates/firestore-database/src/database/event.rs
+++ b/crates/firestore-database/src/database/event.rs
@@ -1,11 +1,10 @@
 use std::collections::HashMap;
 
 use googleapis::google::protobuf::Timestamp;
-use string_cache::DefaultAtom;
 
-use super::document::DocumentVersion;
+use super::{document::DocumentVersion, reference::DocumentRef};
 
 pub struct DatabaseEvent {
     pub update_time: Timestamp,
-    pub updates:     HashMap<DefaultAtom, DocumentVersion>,
+    pub updates:     HashMap<DocumentRef, DocumentVersion>,
 }

--- a/crates/firestore-database/src/database/query.rs
+++ b/crates/firestore-database/src/database/query.rs
@@ -7,8 +7,11 @@ use tonic::{Result, Status};
 
 use self::filter::Filter;
 use super::{
-    collection::Collection, document::StoredDocumentVersion, field_path::FieldReference, Database,
-    ReadConsistency,
+    collection::Collection,
+    document::StoredDocumentVersion,
+    field_path::FieldReference,
+    reference::{CollectionRef, DocumentRef, Ref},
+    Database, ReadConsistency,
 };
 
 mod filter;
@@ -16,7 +19,7 @@ mod filter;
 /// A Firestore query.
 #[derive(Debug)]
 pub struct Query {
-    parent: String,
+    parent: Ref,
 
     /// Optional sub-set of the fields to return.
     ///
@@ -114,7 +117,7 @@ pub struct Query {
 
 impl Query {
     pub fn from_structured(
-        parent: String,
+        parent: Ref,
         query: StructuredQuery,
         consistency: ReadConsistency,
     ) -> Result<Self> {
@@ -178,7 +181,7 @@ impl Query {
         self.order_by.iter().any(|o| !o.field.is_document_name())
     }
 
-    pub async fn once(&mut self, db: &Database) -> Result<Vec<Document>> {
+    pub async fn once(&mut self, db: &Database) -> Result<Vec<(DocumentRef, Document)>> {
         // First collect all Arc<Collection>s in a Vec to release the collection lock asap.
         let collections = self.applicable_collections(db).await;
 
@@ -230,7 +233,7 @@ impl Query {
         buffer
             .into_iter()
             .skip(self.offset)
-            .map(|version| self.project(&version))
+            .map(|version| Ok((version.name.clone(), self.project(&version)?)))
             .try_collect()
     }
 
@@ -244,29 +247,26 @@ impl Query {
             .collect_vec()
     }
 
-    fn includes_collection(&mut self, path: &DefaultAtom) -> bool {
-        if let Some(&r) = self.collection_cache.get(path) {
+    fn includes_collection(&mut self, collection: &CollectionRef) -> bool {
+        if let Some(&r) = self.collection_cache.get(&collection.collection_id) {
             return r;
         }
-        let included = match path
-            .strip_prefix(&self.parent)
-            .and_then(|path| path.strip_prefix('/'))
-        {
-            Some(path) => self.from.iter().any(|selector| {
-                if selector.all_descendants {
-                    path.starts_with(&selector.collection_id)
-                } else {
-                    path == selector.collection_id
-                }
-            }),
-            None => false,
-        };
-        self.collection_cache.insert(path.clone(), included);
+        let included = collection.strip_prefix(&self.parent).is_some_and(|path| {
+            self.from.iter().any(|selector| {
+                path == selector.collection_id
+                    || selector.all_descendants
+                        && path
+                            .strip_prefix(&selector.collection_id)
+                            .is_some_and(|rest| rest.starts_with('/'))
+            })
+        });
+        self.collection_cache
+            .insert(collection.collection_id.clone(), included);
         included
     }
 
     pub fn includes_document(&mut self, doc: &StoredDocumentVersion) -> Result<bool> {
-        if !self.includes_collection(&doc.collection_name) {
+        if !self.includes_collection(&doc.name.collection_ref) {
             return Ok(false);
         }
         if let Some(filter) = &self.filter {

--- a/crates/firestore-database/src/database/reference.rs
+++ b/crates/firestore-database/src/database/reference.rs
@@ -1,0 +1,486 @@
+use std::{fmt::Display, str::FromStr};
+
+use string_cache::DefaultAtom;
+use thiserror::Error;
+
+/// A reference to either the database root (including project name and database name), a single
+/// collection or a single document.
+///
+/// # Examples
+///
+/// ```
+/// # use firestore_database::reference::*;
+/// # fn main() -> Result<(), InvalidReference> {
+/// assert_eq!(
+///     "projects/my-project/databases/my-database".parse::<Ref>()?,
+///     Ref::Root(RootRef::new("my-project", "my-database")),
+/// );
+/// assert_eq!(
+///     "projects/my-project/databases/my-database/documents/my-collection".parse::<Ref>()?,
+///     Ref::Collection(CollectionRef::new(
+///         RootRef::new("my-project", "my-database"),
+///         "my-collection"
+///     ))
+/// );
+/// assert_eq!(
+///     "projects/my-project/databases/my-database/documents/my-collection/my-document"
+///         .parse::<Ref>()?,
+///     Ref::Document(DocumentRef::new(
+///         CollectionRef::new(RootRef::new("my-project", "my-database"), "my-collection"),
+///         "my-document"
+///     ))
+/// );
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Ref {
+    Root(RootRef),
+    Collection(CollectionRef),
+    Document(DocumentRef),
+}
+
+impl Ref {
+    pub fn as_root(&self) -> Option<&RootRef> {
+        if let Self::Root(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_collection(&self) -> Option<&CollectionRef> {
+        if let Self::Collection(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_document(&self) -> Option<&DocumentRef> {
+        if let Self::Document(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    pub fn root(&self) -> &RootRef {
+        match self {
+            Ref::Root(root) => root,
+            Ref::Collection(col) => &col.root_ref,
+            Ref::Document(doc) => &doc.collection_ref.root_ref,
+        }
+    }
+
+    /// Returns whether `self` is a (grand)parent of `other`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use firestore_database::reference::*;
+    /// # fn main() -> Result<(), InvalidReference> {
+    /// let root: Ref = "projects/p/databases/d/documents".parse()?;
+    /// let collection: Ref = "projects/p/databases/d/documents/collection".parse()?;
+    /// let document: Ref = "projects/p/databases/d/documents/collection/document".parse()?;
+    /// assert!(root.is_parent_of(&collection));
+    /// assert!(root.is_parent_of(&document));
+    /// assert!(collection.is_parent_of(&document));
+    /// assert!(!root.is_parent_of(&root));
+    /// assert!(!document.is_parent_of(&root));
+    /// assert!(!collection.is_parent_of(&collection));
+    ///
+    /// let doc_in_other_col: Ref = "projects/p/databases/d/documents/OTHER/document".parse()?;
+    /// assert!(!collection.is_parent_of(&doc_in_other_col));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn is_parent_of(&self, other: &Ref) -> bool {
+        debug_assert_eq!(self.root(), other.root());
+        match (self, other) {
+            (_, Ref::Root(_)) => false,
+            (Ref::Root(_), _) => true,
+            (Ref::Collection(parent), Ref::Collection(child)) => {
+                child.strip_collection_prefix(parent).is_some()
+            }
+            (Ref::Collection(parent), Ref::Document(child)) => {
+                &child.collection_ref == parent
+                    || child
+                        .collection_ref
+                        .strip_collection_prefix(parent)
+                        .is_some()
+            }
+            (Ref::Document(parent), Ref::Collection(child)) => {
+                child.strip_document_prefix(parent).is_some()
+            }
+            (Ref::Document(parent), Ref::Document(child)) => {
+                child.collection_ref.strip_document_prefix(parent).is_some()
+            }
+        }
+    }
+}
+
+impl Display for Ref {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Ref::Root(r) => r.fmt(f),
+            Ref::Collection(r) => r.fmt(f),
+            Ref::Document(r) => r.fmt(f),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("Invalid {0} reference: {1}")]
+pub struct InvalidReference(&'static str, String);
+
+impl From<InvalidReference> for tonic::Status {
+    fn from(value: InvalidReference) -> Self {
+        tonic::Status::invalid_argument(value.to_string())
+    }
+}
+
+impl FromStr for Ref {
+    type Err = InvalidReference;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        fn parse_ref(s: &str) -> Option<Ref> {
+            let s = s.strip_prefix("projects/")?;
+            let (project_id, s) = s.split_once('/')?;
+            let s = s.strip_prefix("databases/")?;
+            let Some((database_id, s)) = s.split_once('/') else {
+                return Some(Ref::Root(RootRef::new(project_id, s)));
+            };
+            let s = s.strip_prefix("documents")?;
+            let root_ref = RootRef::new(project_id, database_id);
+            if s.is_empty() {
+                return Some(Ref::Root(root_ref));
+            }
+            let s = s.strip_prefix('/')?;
+            let slashes = s.chars().filter(|ch| *ch == '/').count();
+            let rf = if slashes % 2 == 0 {
+                Ref::Collection(CollectionRef::new(root_ref, s))
+            } else {
+                let (collection_id, document_id) = s.rsplit_once('/')?;
+                Ref::Document(DocumentRef::new(
+                    CollectionRef::new(root_ref, collection_id),
+                    document_id,
+                ))
+            };
+
+            // TODO: add checks:
+            // - Maximum depth of subcollections    100
+            // - Maximum size for a document name   6 KiB
+            // - Constraints on collection IDs
+            //    - Must be valid UTF-8 characters
+            //    - Must be no longer than 1,500 bytes
+            //    - Cannot contain a forward slash (/)
+            //    - Cannot solely consist of a single period (.) or double periods (..)
+            //    - Cannot match the regular expression __.*__
+            // - Constraints on document IDs
+            //    - Must be valid UTF-8 characters
+            //    - Must be no longer than 1,500 bytes
+            //    - Cannot contain a forward slash (/)
+            //    - Cannot solely consist of a single period (.) or double periods (..)
+            //    - Cannot match the regular expression __.*__
+            //    - (If you import Datastore entities into a Firestore database, numeric entity IDs
+            //      are exposed as __id[0-9]+__)
+
+            Some(rf)
+        }
+
+        parse_ref(s).ok_or_else(|| InvalidReference("database/collection/document", s.to_string()))
+    }
+}
+
+impl From<RootRef> for Ref {
+    fn from(v: RootRef) -> Self {
+        Self::Root(v)
+    }
+}
+
+impl From<DocumentRef> for Ref {
+    fn from(v: DocumentRef) -> Self {
+        Self::Document(v)
+    }
+}
+
+impl From<CollectionRef> for Ref {
+    fn from(v: CollectionRef) -> Self {
+        Self::Collection(v)
+    }
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RootRef {
+    pub project_id:  DefaultAtom,
+    pub database_id: DefaultAtom,
+}
+
+impl FromStr for RootRef {
+    type Err = InvalidReference;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let rf: Ref = s.parse()?;
+        rf.as_root()
+            .cloned()
+            .ok_or_else(|| InvalidReference("database", s.to_string()))
+    }
+}
+
+impl Display for RootRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "projects/{}/databases/{}/documents",
+            self.project_id, self.database_id,
+        )
+    }
+}
+
+impl RootRef {
+    pub fn new(project_id: impl Into<DefaultAtom>, database_id: impl Into<DefaultAtom>) -> Self {
+        Self {
+            project_id:  project_id.into(),
+            database_id: database_id.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CollectionRef {
+    pub root_ref:      RootRef,
+    pub collection_id: DefaultAtom,
+}
+
+impl FromStr for CollectionRef {
+    type Err = InvalidReference;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let rf: Ref = s.parse()?;
+        rf.as_collection()
+            .cloned()
+            .ok_or_else(|| InvalidReference("collection", s.to_string()))
+    }
+}
+
+impl Display for CollectionRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.root_ref, self.collection_id,)
+    }
+}
+
+impl CollectionRef {
+    pub fn new(root_ref: RootRef, collection_id: impl Into<DefaultAtom>) -> Self {
+        Self {
+            root_ref,
+            collection_id: collection_id.into(),
+        }
+    }
+
+    /// Returns the remaining canonical reference string when the given reference `r` has been
+    /// removed as prefix. Can also be used to efficiently determine whether the given `r` is a
+    /// parent of this collection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use firestore_database::reference::*;
+    /// # fn main() -> Result<(), InvalidReference> {
+    /// let parent: Ref = "projects/p/databases/d/documents/parent".parse()?;
+    /// let child: CollectionRef = "projects/p/databases/d/documents/parent/doc/child".parse()?;
+    /// assert_eq!(child.strip_prefix(&parent), Some("doc/child"));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn strip_prefix(&self, r: &Ref) -> Option<&str> {
+        match r {
+            Ref::Root(root) => Some(self.strip_root_prefix(root)),
+            Ref::Collection(col) => self.strip_collection_prefix(col),
+            Ref::Document(doc) => self.strip_document_prefix(doc),
+        }
+    }
+
+    /// Returns the remaining canonical reference string when the given `root` has been removed as
+    /// prefix. Note that this becomes a no-op in release mode, because we assume that references
+    /// from different databases are never compared to each other.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use firestore_database::reference::*;
+    /// # fn main() -> Result<(), InvalidReference> {
+    /// let parent: RootRef = "projects/p/databases/d/documents".parse()?;
+    /// let child: CollectionRef = "projects/p/databases/d/documents/parent/doc/child".parse()?;
+    /// assert_eq!(child.strip_root_prefix(&parent), "parent/doc/child");
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn strip_root_prefix(&self, root: &RootRef) -> &str {
+        debug_assert_eq!(&self.root_ref, root);
+        &self.collection_id
+    }
+
+    /// Returns the remaining canonical reference string when the given `col` has been removed as
+    /// prefix. Can also be used to efficiently determine whether the given `col` is a parent of
+    /// this collection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use firestore_database::reference::*;
+    /// # fn main() -> Result<(), InvalidReference> {
+    /// let parent: CollectionRef = "projects/p/databases/d/documents/parent".parse()?;
+    /// let child: CollectionRef = "projects/p/databases/d/documents/parent/doc/child".parse()?;
+    /// assert_eq!(child.strip_collection_prefix(&parent), Some("doc/child"));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn strip_collection_prefix(&self, col: &CollectionRef) -> Option<&str> {
+        let rest = self
+            .strip_root_prefix(&col.root_ref)
+            .strip_prefix(&*col.collection_id)?
+            .strip_prefix('/')?;
+        Some(rest)
+    }
+
+    /// Returns the remaining canonical reference string when the given `doc` has been removed as
+    /// prefix. Can also be used to efficiently determine whether the given `doc` is a parent of
+    /// this collection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use firestore_database::reference::*;
+    /// # fn main() -> Result<(), InvalidReference> {
+    /// let parent: DocumentRef = "projects/p/databases/d/documents/parent/doc".parse()?;
+    /// let child: CollectionRef = "projects/p/databases/d/documents/parent/doc/child".parse()?;
+    /// assert_eq!(child.strip_document_prefix(&parent), Some("child"));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn strip_document_prefix(&self, doc: &DocumentRef) -> Option<&str> {
+        let rest = self
+            .strip_collection_prefix(&doc.collection_ref)?
+            .strip_prefix(&*doc.document_id)?
+            .strip_prefix('/')?;
+        Some(rest)
+    }
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct DocumentRef {
+    pub collection_ref: CollectionRef,
+    pub document_id:    DefaultAtom,
+}
+
+impl FromStr for DocumentRef {
+    type Err = InvalidReference;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let rf: Ref = s.parse()?;
+        rf.as_document()
+            .cloned()
+            .ok_or_else(|| InvalidReference("document", s.to_string()))
+    }
+}
+impl Display for DocumentRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}/{}", self.collection_ref, self.document_id,)
+    }
+}
+
+impl DocumentRef {
+    pub fn new(collection_ref: CollectionRef, document_id: impl Into<DefaultAtom>) -> Self {
+        Self {
+            collection_ref,
+            document_id: document_id.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    #[rstest]
+    #[case(
+        // With `/documents` suffix
+        "projects/my-demo-project/databases/database/documents",
+        "my-demo-project",
+        "database"
+    )]
+    #[case(
+        // Without `/documents` suffix
+        "projects/demo-project/databases/(default)",
+        "demo-project",
+        "(default)"
+    )]
+    fn parse_root_ref(#[case] input: &str, #[case] project_id: &str, #[case] database_id: &str) {
+        assert_eq!(
+            input.parse::<Ref>().unwrap(),
+            Ref::Root(RootRef::new(project_id, database_id))
+        )
+    }
+
+    #[rstest]
+    #[case(
+        "projects/proj/databases/database/documents/collection",
+        "proj",
+        "database",
+        "collection"
+    )]
+    #[case(
+        "projects/demo-project/databases/(default)/documents/root/doc/sub",
+        "demo-project",
+        "(default)",
+        "root/doc/sub"
+    )]
+    fn parse_collection_refs(
+        #[case] input: &str,
+        #[case] project_id: &str,
+        #[case] database_id: &str,
+        #[case] collection_id: &str,
+    ) {
+        assert_eq!(
+            input.parse::<Ref>().unwrap(),
+            Ref::Collection(CollectionRef::new(
+                RootRef::new(project_id, database_id),
+                collection_id
+            ))
+        );
+    }
+
+    #[rstest]
+    #[case(
+        "projects/proj/databases/database/documents/collection/document",
+        "proj",
+        "database",
+        "collection",
+        "document"
+    )]
+    #[case(
+        "projects/demo-project/databases/(default)/documents/root/doc/sub/doc",
+        "demo-project",
+        "(default)",
+        "root/doc/sub",
+        "doc"
+    )]
+    fn parse_document_refs(
+        #[case] input: &str,
+        #[case] project_id: &str,
+        #[case] database_id: &str,
+        #[case] collection_id: &str,
+        #[case] doc_id: &str,
+    ) {
+        assert_eq!(
+            input.parse::<Ref>().unwrap(),
+            Ref::Document(DocumentRef::new(
+                CollectionRef::new(RootRef::new(project_id, database_id), collection_id),
+                doc_id
+            ))
+        );
+    }
+}

--- a/crates/firestore-database/src/lib.rs
+++ b/crates/firestore-database/src/lib.rs
@@ -1,4 +1,4 @@
 mod database;
 pub use database::*;
 #[macro_use]
-mod utils;
+pub mod utils;

--- a/crates/googleapis/Cargo.toml
+++ b/crates/googleapis/Cargo.toml
@@ -16,3 +16,4 @@ tonic-build = "0.11"
 
 [dev-dependencies]
 itertools = "0.12.1"
+rstest = "0.18.2"


### PR DESCRIPTION
This change adds a new enum `Ref` which represents a reference to either the database root, a single collection, or a single document in a Firestore database. It includes methods to extract the different types of references, check if one reference is a parent of another, and implements the `Display` trait for formatting. Additionally, it introduces error handling for invalid references and conversion to `tonic::Status`. The implementation also includes parsing logic from string to create a `Ref` instance.