### PR TITLE
refactor: Reorganized imports and added new module for read_consistency

### DIFF
--- a/crates/emulator-grpc/src/lib.rs
+++ b/crates/emulator-grpc/src/lib.rs
@@ -3,8 +3,9 @@ use std::sync::Arc;
 use firestore_database::{
     event::DatabaseEvent,
     get_doc_name_from_write,
+    read_consistency::ReadConsistency,
     reference::{DocumentRef, Ref},
-    FirestoreDatabase, FirestoreProject, ReadConsistency,
+    FirestoreDatabase, FirestoreProject,
 };
 use futures::{future::try_join_all, stream::BoxStream, TryStreamExt};
 use googleapis::google::{

--- a/crates/emulator-ui/src/routes/emulator.rs
+++ b/crates/emulator-ui/src/routes/emulator.rs
@@ -5,7 +5,7 @@ use axum::{
     routing::get,
     Json, Router,
 };
-use firestore_database::{reference::Ref, FirestoreProject, ReadConsistency};
+use firestore_database::{read_consistency::ReadConsistency, reference::Ref, FirestoreProject};
 use serde_json::json;
 use tower_http::set_header::SetResponseHeaderLayer;
 

--- a/crates/firestore-database/src/database/document.rs
+++ b/crates/firestore-database/src/database/document.rs
@@ -20,7 +20,7 @@ use tokio::{
 };
 use tracing::{instrument, trace, Level};
 
-use super::{reference::DocumentRef, ReadConsistency};
+use super::{read_consistency::ReadConsistency, reference::DocumentRef};
 use crate::{error::Result, GenericDatabaseError};
 
 const WAIT_LOCK_TIMEOUT: Duration = Duration::from_secs(30);

--- a/crates/firestore-database/src/database/query.rs
+++ b/crates/firestore-database/src/database/query.rs
@@ -9,8 +9,9 @@ use super::{
     collection::Collection,
     document::StoredDocumentVersion,
     field_path::FieldReference,
+    read_consistency::ReadConsistency,
     reference::{CollectionRef, DocumentRef, Ref},
-    FirestoreDatabase, ReadConsistency,
+    FirestoreDatabase,
 };
 use crate::{error::Result, GenericDatabaseError};
 

--- a/crates/firestore-database/src/database/read_consistency.rs
+++ b/crates/firestore-database/src/database/read_consistency.rs
@@ -1,0 +1,60 @@
+use googleapis::google::{
+    firestore::v1::{
+        batch_get_documents_request, get_document_request, list_documents_request,
+        run_aggregation_query_request, run_query_request,
+    },
+    protobuf::Timestamp,
+};
+
+use crate::{database::transaction::TransactionId, error::GenericDatabaseError};
+
+#[derive(Clone, Debug)]
+pub enum ReadConsistency {
+    Default,
+    ReadTime(Timestamp),
+    Transaction(TransactionId),
+}
+
+impl ReadConsistency {
+    /// Returns `true` if the read consistency is [`Transaction`].
+    ///
+    /// [`Transaction`]: ReadConsistency::Transaction
+    #[must_use]
+    pub fn is_transaction(&self) -> bool {
+        matches!(self, Self::Transaction(..))
+    }
+}
+
+macro_rules! impl_try_from_consistency_selector {
+    ($lib:ident) => {
+        impl TryFrom<Option<$lib::ConsistencySelector>> for ReadConsistency {
+            type Error = GenericDatabaseError;
+
+            fn try_from(value: Option<$lib::ConsistencySelector>) -> Result<Self, Self::Error> {
+                let result = match value {
+                    None => ReadConsistency::Default,
+                    Some($lib::ConsistencySelector::ReadTime(time)) => {
+                        ReadConsistency::ReadTime(time)
+                    }
+                    Some($lib::ConsistencySelector::Transaction(id)) => {
+                        ReadConsistency::Transaction(id.try_into()?)
+                    }
+                    #[allow(unreachable_patterns)]
+                    _ => {
+                        return Err(GenericDatabaseError::internal(concat!(
+                            stringify!($lib),
+                            "::ConsistencySelector::NewTransaction should be handled by caller"
+                        )));
+                    }
+                };
+                Ok(result)
+            }
+        }
+    };
+}
+
+impl_try_from_consistency_selector!(batch_get_documents_request);
+impl_try_from_consistency_selector!(get_document_request);
+impl_try_from_consistency_selector!(list_documents_request);
+impl_try_from_consistency_selector!(run_query_request);
+impl_try_from_consistency_selector!(run_aggregation_query_request);

--- a/crates/firestore-database/src/listener.rs
+++ b/crates/firestore-database/src/listener.rs
@@ -26,7 +26,7 @@ use tokio_stream::{
 use tracing::{debug, error, info, instrument};
 
 use crate::{
-    database::{reference::Ref, ReadConsistency},
+    database::{read_consistency::ReadConsistency, reference::Ref},
     document::DocumentVersion,
     error::Result,
     event::DatabaseEvent,


### PR DESCRIPTION
The changes include reorganized imports in multiple files to group related imports together for better readability. Additionally, a new module for read_consistency has been added to the project to handle consistency settings in Firestore. This modular approach improves code organization and maintenance.