### PR TITLE
feat: Add graceful shutdown signal handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,6 +1710,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,6 +1899,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ emulator-ui = { path = "crates/emulator-ui" }
 hybrid-axum-tonic = { path = "crates/hybrid-axum-tonic" }
 tikv-jemallocator = "0.5.4"
 time = { workspace = true, optional = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
 tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.18", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,22 +1,34 @@
-use std::net::SocketAddr;
+use std::{future::Future, net::SocketAddr};
 
 use axum::Router;
 use hybrid_axum_tonic::{NestTonic, RestGrpcService};
-use tracing::info;
+use tracing::{enabled, info, Level};
 
 #[tokio::main]
-pub async fn run(host_port: SocketAddr) -> color_eyre::Result<()> {
+pub async fn run(
+    host_port: SocketAddr,
+    shutdown: impl Future<Output = ()>,
+) -> color_eyre::Result<()> {
     let rest_router = emulator_ui::router();
     let grpc_router = Router::new().nest_tonic(emulator_grpc::service());
     let combined = RestGrpcService::new(rest_router, grpc_router).into_make_service();
-    let server = axum::Server::bind(&host_port).serve(combined);
+    let server = axum::Server::bind(&host_port)
+        .serve(combined)
+        .with_graceful_shutdown(shutdown);
 
-    info!("Firestore listening on {}", host_port);
-
-    #[cfg(not(feature = "tracing"))]
-    eprintln!("Firestore listening on {}", host_port);
+    if enabled!(Level::INFO) {
+        info!("Firestore emulator listening on {}", host_port);
+    } else {
+        eprintln!("Firestore emulator listening on {}", host_port);
+    }
 
     server.await?;
+
+    if enabled!(Level::INFO) {
+        info!("Firestore emulator stopped");
+    } else {
+        eprintln!("Firestore emulator stopped");
+    }
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::net::SocketAddr;
 use clap::Parser;
 use firestore_emulator::run;
 use tikv_jemallocator::Jemalloc;
+use tokio::signal::ctrl_c;
 
 #[global_allocator]
 static GLOBAL_ALLOC: Jemalloc = Jemalloc;
@@ -44,5 +45,7 @@ fn main() -> color_eyre::Result<()> {
         registry.init();
     }
 
-    run(Args::parse().host_port)
+    let ctrl_c_listener = async { ctrl_c().await.expect("failed to listen for ctrl-c event") };
+
+    run(Args::parse().host_port, ctrl_c_listener)
 }


### PR DESCRIPTION
Introduce graceful shutdown signal handling to the Firestore emulator.
This allows the emulator to listen for the Ctrl-C event and stop
gracefully when it occurs.