### PR TITLE
refactor: Implement validation for multiple array contains clauses

### DIFF
--- a/test-suite/tests/2-basic-query.test.ts
+++ b/test-suite/tests/2-basic-query.test.ts
@@ -273,6 +273,15 @@ describe.each([
                 '3 INVALID_ARGUMENT: Cannot have inequality filters on multiple properties: [`backticks`.nested, type]',
             );
         });
+
+        test('multiple array contains (should not be possible)', async () => {
+            // Workaround for bug in FieldPath: https://github.com/googleapis/nodejs-firestore/issues/2019
+            const path = new fs.exported.FieldPath('tbd');
+            Object.defineProperty(path, 'formattedName', { value: '`\\`backticks\\``.nested' });
+            await expect(
+                getData(collection.where(path, 'array-contains', 'data').where('type', 'array-contains-any', [1, 2])),
+            ).rejects.toThrow('Only a single array-contains clause is allowed in a query');
+        });
     });
 
     describe('paginating results', () => {


### PR DESCRIPTION
- Refactored the `get_inequality_fields` method in the Filter enum to use
  `impl Iterator` for efficiency.
- Implemented `field_filters` and `depth_first` methods in Filter to provide
  better functionality for processing filters.
- Added `as_composite`, `as_field`, and `as_unary` methods to simplify filter
  conversion in the Filter enum.