### PR TITLE
feat: Reduce testing concurrency in CI and add transaction id field in logging

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -71,7 +71,7 @@ jobs:
           cache: npm
           cache-dependency-path: test-suite/package-lock.json
       - name: Run compatibility test suite
-        run: npm ci && npm run test:rust-emulator
+        run: npm ci && npm run test:rust-emulator -- --maxConcurrency=3
         working-directory: test-suite
 
   deploy:

--- a/crates/firestore-database/src/database/document.rs
+++ b/crates/firestore-database/src/database/document.rs
@@ -22,7 +22,7 @@ use tokio::{
 };
 use tracing::{debug, instrument, trace, warn, Level};
 
-use super::{read_consistency::ReadConsistency, reference::DocumentRef};
+use super::reference::DocumentRef;
 use crate::{error::Result, FirestoreProject, GenericDatabaseError};
 
 pub struct DocumentMeta {
@@ -123,17 +123,6 @@ impl DocumentContents {
             .iter()
             .rfind(|version| (version.update_time()) <= (read_time))
             .and_then(DocumentVersion::stored_document)
-    }
-
-    pub fn version_for_consistency(
-        &self,
-        consistency: ReadConsistency,
-    ) -> Result<Option<&Arc<StoredDocumentVersion>>> {
-        Ok(match consistency {
-            ReadConsistency::Default => self.current_version(),
-            ReadConsistency::ReadTime(time) => self.version_at_time(time),
-            ReadConsistency::Transaction(_) => self.current_version(),
-        })
     }
 
     pub fn exists(&self) -> bool {

--- a/crates/firestore-database/src/database/read_consistency.rs
+++ b/crates/firestore-database/src/database/read_consistency.rs
@@ -1,7 +1,7 @@
 use googleapis::google::{
     firestore::v1::{
         batch_get_documents_request, get_document_request, list_documents_request,
-        run_aggregation_query_request, run_query_request, transaction_options,
+        run_aggregation_query_request, run_query_request,
     },
     protobuf::Timestamp,
 };
@@ -56,14 +56,3 @@ impl_try_from_consistency_selector!(get_document_request);
 impl_try_from_consistency_selector!(list_documents_request);
 impl_try_from_consistency_selector!(run_query_request);
 impl_try_from_consistency_selector!(run_aggregation_query_request);
-
-impl From<Option<transaction_options::read_only::ConsistencySelector>> for ReadConsistency {
-    fn from(value: Option<transaction_options::read_only::ConsistencySelector>) -> Self {
-        match value {
-            Some(transaction_options::read_only::ConsistencySelector::ReadTime(time)) => {
-                Self::ReadTime(time)
-            }
-            None => Self::Default,
-        }
-    }
-}


### PR DESCRIPTION
Reduce testing concurrency by setting maxConcurrency to 3 in the Rust emulator test.
Add a transaction id field in the logging for better tracking and debugging.